### PR TITLE
Separate created objects cache for each test case class

### DIFF
--- a/admin_smoke/tests.py
+++ b/admin_smoke/tests.py
@@ -109,6 +109,13 @@ class BaseTestCase(TimeMixin, TestCase, metaclass=BaseTestCaseMeta):
             # noinspection PyProtectedMember
             obj._state.fields_cache.clear()
 
+    @classmethod
+    def forget_object(cls, obj: models.Model):
+        """
+        Method for removing django model instance from created objects cache
+        """
+        cls._created_objects.remove((obj.pk, obj))
+
     @staticmethod
     def update_object(obj, *args, **kwargs):
         """ Update django model object in database only."""

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -1,6 +1,6 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-from admin_smoke.tests import AdminTests, AdminBaseTestCase
+from admin_smoke.tests import AdminTests, AdminBaseTestCase, BaseTestCase
 from testproject.testapp import admin, models
 
 
@@ -30,3 +30,29 @@ class ProjectAdminTestCase(AdminTests, AdminBaseTestCase):
 
     def prepare_deletion(self):
         self.task.delete()
+
+
+class BaseTestCaseMetaTestCase(BaseTestCase):
+    """ Tests for base testcase metaclass."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.project = models.Project.objects.create(name='project')
+        cls.project2 = models.Project.objects.create(name='project2')
+        cls.forget_object(cls.project2)
+        cls.project2.delete()
+
+    def test_1_first(self):
+        """ Modify something in memory."""
+        self.project.name = 'modified'
+        self.project.save()
+
+        self.project2.name = 'modified2'
+
+    def test_2_second(self):
+        """ class attributes are reset correctly."""
+        # This test fill pass only if running whole test case
+        self.assertEqual(self.project.name, "project")
+        # forgotten object is in modified state
+        self.assertEqual(self.project2.name, "modified2")


### PR DESCRIPTION
BUG: _created_objects cache was shared between all test cases
FIX: metaclass now adds it's own _created_objects list to each subclassed testcase
OPTIMIZATION: ObjectDoesNotExist exception handling in refresh_objects seems not used anymore, so it's removed.